### PR TITLE
update slirp4netns and fuse-overlayfs

### DIFF
--- a/scripts/package
+++ b/scripts/package
@@ -22,8 +22,8 @@ cp buildroot/output/target/usr/sbin/swanctl /source/artifacts/${BUILDARCH}/bin/
 cp buildroot/output/target/usr/libexec/ipsec/charon /source/artifacts/${BUILDARCH}/bin/
 
 # download pre-built binaries
-SLIRP4NETNS_VERSION="v1.1.4"
-FUSE_OVERLAYFS="v1.2.0"
+SLIRP4NETNS_VERSION="v1.1.8"
+FUSE_OVERLAYFS="v1.3.0"
 uname_m="${BUILDARCH}"
 case "${BUILDARCH}" in
     "amd64")


### PR DESCRIPTION
Changes:
- https://github.com/rootless-containers/slirp4netns/releases
- https://github.com/containers/fuse-overlayfs/releases

Notably, this release of slirp4netns fixes stability issue related to UDP packets.
