### PR TITLE
Fix fuse-overlay binary shows Not Found

### DIFF
--- a/scripts/package
+++ b/scripts/package
@@ -23,7 +23,7 @@ cp buildroot/output/target/usr/libexec/ipsec/charon /source/artifacts/${BUILDARC
 
 # download pre-built binaries
 SLIRP4NETNS_VERSION="v1.1.8"
-FUSE_OVERLAYFS="v1.3.0"
+FUSE_OVERLAYFS_VERSION="v1.3.0"
 uname_m="${BUILDARCH}"
 case "${BUILDARCH}" in
     "amd64")

--- a/scripts/package
+++ b/scripts/package
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eu
 
 mkdir -p /source/artifacts/${BUILDARCH}/bin /source/artifacts/${BUILDARCH}/xtables-bin /source/artifacts/${BUILDARCH}/etc /source/dist
 


### PR DESCRIPTION
The bin/fuse-overlay binary does not download at all.

Right now, the fuse-overlay in release v0.7.1 and v0.7.2 both shown "Not Found".
Align the environment variable to be `FUSE_OVERLAYFS_VERSION`.

related to https://github.com/k3s-io/k3s/issues/2817

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>