### PR TITLE
Patch out !BR2_STATIC_LIBS condition on BR2_PACKAGE_IPTABLES_NFTABLES

### DIFF
--- a/patches/iptables.patch
+++ b/patches/iptables.patch
@@ -1,0 +1,19 @@
+diff -ru buildroot.orig/package/iptables/Config.in buildroot/package/iptables/Config.in
+--- buildroot.orig/package/iptables/Config.in	2020-12-27 14:23:34.000000000 +0000
++++ buildroot/package/iptables/Config.in	2021-02-17 23:46:17.941771567 +0000
+@@ -16,7 +16,6 @@
+ config BR2_PACKAGE_IPTABLES_NFTABLES
+ 	bool "nftables compat"
+ 	# uses dlfcn
+-	depends on !BR2_STATIC_LIBS
+ 	depends on BR2_USE_WCHAR
+ 	depends on BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_12
+ 	select BR2_PACKAGE_LIBMNL
+@@ -26,6 +25,6 @@
+
+ comment "nftables compat needs a toolchain w/ wchar, dynamic library, headers >= 3.12"
+ 	depends on !BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_12 || \
+-		!BR2_USE_WCHAR || BR2_STATIC_LIBS
++		!BR2_USE_WCHAR
+
+ endif

--- a/scripts/ci
+++ b/scripts/ci
@@ -6,5 +6,6 @@ cd "$(dirname $0)"
 echo "Buildarch is $BUILDARCH"
 
 ./download
+./patch
 ./build
 ./package

--- a/scripts/patch
+++ b/scripts/patch
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -ex
+shopt -s nullglob
+
+pushd /usr/src/buildroot
+
+for PATCH in /source/patches/*.patch; do
+  patch --verbose -t -p1 -i $PATCH
+done


### PR DESCRIPTION
In addition to providing a newer version of iptables, @Oats87 had also been commenting out some build config that disabled BR2_PACKAGE_IPTABLES_NFTABLES if BR2_STATIC_LIBS was set. Unfortunately that wasn't clear, and I dropped that change when I dropped our now-old iptables replacement.

Fix that by specifically patching the buildroot config script to remove the static check.

k3s-io/k3s#2940