### PR TITLE
update slirp4netns (v1.1.11) and fuse-overlayfs (v1.5.0)

### DIFF
--- a/scripts/package
+++ b/scripts/package
@@ -23,8 +23,8 @@ cp buildroot/output/target/usr/sbin/swanctl /source/artifacts/${BUILDARCH}/bin/
 cp buildroot/output/target/usr/libexec/ipsec/charon /source/artifacts/${BUILDARCH}/bin/
 
 # download pre-built binaries
-SLIRP4NETNS_VERSION="v1.1.8"
-FUSE_OVERLAYFS_VERSION="v1.3.0"
+SLIRP4NETNS_VERSION="v1.1.11"
+FUSE_OVERLAYFS_VERSION="v1.5.0"
 uname_m="${BUILDARCH}"
 case "${BUILDARCH}" in
     "amd64")


### PR DESCRIPTION
slirp4netns:    v1.1.8 -> v1.1.11 (https://github.com/rootless-containers/slirp4netns/releases)
fuse-overlayfs: v1.3.0 -> v1.5.0  (https://github.com/containers/fuse-overlayfs/releases)

- - -

Contains the fix for CVE-2021-{3592,3593,3594,3595} (libslirp v4.5.0 -> v4.6.0) https://gitlab.freedesktop.org/slirp/libslirp/-/blob/v4.6.0/CHANGELOG.md