### PR TITLE
Drop socat from config

### DIFF
--- a/buildroot/config
+++ b/buildroot/config
@@ -3791,7 +3791,7 @@ BR2_PACKAGE_IPTABLES_NFTABLES=y
 #
 # snort3 needs a toolchain w/ C++, wchar, threads, dynamic library, gcc >= 4.9
 #
-BR2_PACKAGE_SOCAT=y
+# BR2_PACKAGE_SOCAT is not set
 # BR2_PACKAGE_SOCKETCAND is not set
 # BR2_PACKAGE_SOFTETHER is not set
 # BR2_PACKAGE_SPAWN_FCGI is not set

--- a/scripts/package
+++ b/scripts/package
@@ -9,12 +9,12 @@ mkdir -p \
 pushd /usr/src
 
 # copy binaries
-cp -d buildroot/output/target/usr/sbin/*tables*                         "/source/artifacts/${BUILDARCH}/bin/"
-cp buildroot/output/target/usr/sbin/{conntrack,ethtool,ipset}           "/source/artifacts/${BUILDARCH}/bin/"
-cp buildroot/output/target/usr/bin/{find,nsenter,pigz,socat,coreutils}  "/source/artifacts/${BUILDARCH}/bin/"
-cp buildroot/output/target/usr/bin/{slirp4netns,fuse-overlayfs}         "/source/artifacts/${BUILDARCH}/bin/"
-cp buildroot/output/target/sbin/{blkid,ip,losetup}                      "/source/artifacts/${BUILDARCH}/bin/"
-cp buildroot/output/target/bin/busybox                                  "/source/artifacts/${BUILDARCH}/bin/"
+cp -d buildroot/output/target/usr/sbin/*tables*                  "/source/artifacts/${BUILDARCH}/bin/"
+cp buildroot/output/target/usr/sbin/{conntrack,ethtool,ipset}    "/source/artifacts/${BUILDARCH}/bin/"
+cp buildroot/output/target/usr/bin/{find,nsenter,pigz,coreutils} "/source/artifacts/${BUILDARCH}/bin/"
+cp buildroot/output/target/usr/bin/{slirp4netns,fuse-overlayfs}  "/source/artifacts/${BUILDARCH}/bin/"
+cp buildroot/output/target/sbin/{blkid,ip,losetup}               "/source/artifacts/${BUILDARCH}/bin/"
+cp buildroot/output/target/bin/busybox                           "/source/artifacts/${BUILDARCH}/bin/"
 
 cp -r /source/iptables-detect/*.sh "/source/artifacts/${BUILDARCH}/xtables-bin/"
 


### PR DESCRIPTION
We have been stripping this out on the K3s side for a while, no point in building it.

Ref: https://github.com/k3s-io/k3s/blob/1f3e8f69d4af467b3bd0d3267d61798831488100/scripts/download#L23