### PR TITLE
Support RISC-V

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -257,4 +257,51 @@ volumes:
   host:
     path: /var/run/docker.sock
 
+---
+kind: pipeline
+type: docker
+name: k3s-root-linux-riscv64
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: build-riscv64
+  image: rancher/dapper:v0.5.0
+  commands:
+  - dapper ci
+  environment:
+    BUILDARCH: riscv64
+    VERBOSE: "0"
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+
+- name: github-riscv64-binary-release
+  image: plugins/github-release
+  settings:
+    api_key:
+      from_secret: github_token
+    checksum:
+    - sha256
+    checksum_file: CHECKSUMsum-riscv64.txt
+    checksum_flatten: true
+    files:
+    - dist/k3s-*riscv64.tar
+    prerelease: true
+  when:
+    event:
+    - tag
+    instance:
+    - drone-publish.k3s.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
+
+volumes:
+- name: docker
+  host:
+    path: /var/run/docker.sock
+
 ...

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ARCH ?= amd64
-ALL_ARCH = amd64 arm64 arm ppc64le s390x
+ALL_ARCH = amd64 arm64 arm ppc64le s390x riscv64
 
 export BUILDARCH = $(ARCH)
 export VERBOSE ?= 1

--- a/buildroot/riscv64config
+++ b/buildroot/riscv64config
@@ -1,0 +1,40 @@
+#
+# Target options
+#
+BR2_ARCH_IS_64=y
+BR2_USE_MMU=y
+# BR2_arcle is not set
+# BR2_arceb is not set
+# BR2_arm is not set
+# BR2_armeb is not set
+# BR2_aarch64 is not set
+# BR2_aarch64_be is not set
+# BR2_i386 is not set
+# BR2_m68k is not set
+# BR2_microblazeel is not set
+# BR2_microblazebe is not set
+# BR2_mips is not set
+# BR2_mipsel is not set
+# BR2_mips64 is not set
+# BR2_mips64el is not set
+# BR2_nios2 is not set
+# BR2_or1k is not set
+# BR2_powerpc is not set
+# BR2_powerpc64 is not set
+# BR2_powerpc64le is not set
+BR2_riscv=y
+# BR2_s390 is not set
+# BR2_sh is not set
+# BR2_sparc is not set
+# BR2_sparc64 is not set
+# BR2_x86_64 is not set
+# BR2_xtensa is not set
+BR2_ARCH_HAS_TOOLCHAIN_BUILDROOT=y
+BR2_ARCH="riscv64"
+BR2_NORMALIZED_ARCH="riscv"
+BR2_ENDIAN="LITTLE"
+BR2_GCC_TARGET_ARCH="riscv64"
+BR2_BINFMT_SUPPORTS_SHARED=y
+BR2_READELF_ARCH_NAME="RISC-V"
+BR2_BINFMT_ELF=y
+BR2_RISCV_64=y


### PR DESCRIPTION
Buildroot already supports RISC-V, so it seems trivial to add this architecture to the list and move a step closer to [RISC-V support for K3S](https://github.com/k3s-io/k3s/issues/7151)).

I have already tested this manually, by running the `scripts/ci` script inside an Ubuntu 22.04 container with all necessary development tools. I also include the additional architecture in the Drone file.