### PR TITLE
ci: configure Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+ updates:
+   - package-ecosystem: "docker"
+     directory: "/"
+     schedule:
+       interval: "daily"


### PR DESCRIPTION
Configure Dependabot for daily updates to container images in Dockerfiles.

Related-to: k3s-io/k3s#7440