### PR TITLE
Add nftables binary

### DIFF
--- a/buildroot/config
+++ b/buildroot/config
@@ -3474,7 +3474,7 @@ BR2_PACKAGE_PROTOBUF_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBFRIBIDI is not set
 # BR2_PACKAGE_LIBUNIBREAK is not set
 # BR2_PACKAGE_LIBUNISTRING is not set
-# BR2_PACKAGE_LINENOISE is not set
+BR2_PACKAGE_LINENOISE=y
 # BR2_PACKAGE_NCURSES is not set
 
 #
@@ -3905,7 +3905,7 @@ BR2_PACKAGE_IPTABLES_NFTABLES=y
 # NetworkManager needs udev /dev management and a glibc toolchain w/ headers >= 4.6, dynamic library, wchar, threads, gcc >= 4.9
 #
 # BR2_PACKAGE_NFACCT is not set
-# BR2_PACKAGE_NFTABLES is not set
+BR2_PACKAGE_NFTABLES=y
 # BR2_PACKAGE_NGINX is not set
 # BR2_PACKAGE_NGIRCD is not set
 # BR2_PACKAGE_NGREP is not set

--- a/scripts/download
+++ b/scripts/download
@@ -2,7 +2,7 @@
 
 set -eux -o pipefail
 
-: "${BUILDROOT_VERSION:=2024.02.3}"
+: "${BUILDROOT_VERSION:=2024.02.7}"
 export BUILDROOT_VERSION
 
 mkdir -p /usr/src/buildroot

--- a/scripts/package
+++ b/scripts/package
@@ -4,7 +4,8 @@ set -eux -o pipefail
 
 mkdir -p \
     /source/dist \
-    /source/artifacts/"${BUILDARCH}"/{bin,etc,xtables-bin}
+    /source/artifacts/"${BUILDARCH}"/{bin,etc,xtables-bin} \
+    /source/artifacts/"${BUILDARCH}"/bin/aux
 
 pushd /usr/src
 
@@ -14,6 +15,7 @@ cp buildroot/output/target/usr/sbin/{conntrack,ethtool,ipset}    "/source/artifa
 cp buildroot/output/target/usr/bin/{coreutils,find,fuse-overlayfs,nsenter,pigz,slirp4netns,xargs} "/source/artifacts/${BUILDARCH}/bin/"
 cp buildroot/output/target/sbin/{blkid,ip,losetup}               "/source/artifacts/${BUILDARCH}/bin/"
 cp buildroot/output/target/bin/busybox                           "/source/artifacts/${BUILDARCH}/bin/"
+cp buildroot/output/target/usr/sbin/nft                          "/source/artifacts/${BUILDARCH}/bin/aux/"
 
 cp -r /source/iptables-detect/*.sh "/source/artifacts/${BUILDARCH}/xtables-bin/"
 
@@ -31,7 +33,6 @@ ln -sf pigz "/source/artifacts/${BUILDARCH}/bin/unpigz"
 rm -f "/source/artifacts/${BUILDARCH}/bin/mount"
 rm -f "/source/artifacts/${BUILDARCH}/bin/modprobe"
 
-mkdir -p "/source/artifacts/${BUILDARCH}/bin/aux"
 ln -sf ../busybox "/source/artifacts/${BUILDARCH}/bin/aux/mount"
 ln -sf ../busybox "/source/artifacts/${BUILDARCH}/bin/aux/modprobe"
 
@@ -43,5 +44,6 @@ cp -rp /source/artifacts/"${BUILDARCH}"/xtables-bin/* "/source/artifacts/${BUILD
 
 tar cf - -C "/source/artifacts/${BUILDARCH}" ./bin ./etc > "/source/dist/k3s-root-${BUILDARCH}.tar"
 tar cf - -C "/source/artifacts/${BUILDARCH}" --transform s/xtables-bin/bin/ ./xtables-bin > "/source/dist/k3s-root-xtables-${BUILDARCH}.tar"
+tar -vtf "/source/dist/k3s-root-${BUILDARCH}.tar"
 
 popd


### PR DESCRIPTION
* Bump buildroot from 2024.02.3 -> 2024.02.7 for security updates: https://gitlab.com/buildroot.org/buildroot/-/blob/2024.02.7/CHANGES
* Adds the `nft` binary: https://github.com/k3s-io/k3s/issues/11267

nft is larger than busybox, but smaller than slirp4netns which we keep around just for rootless:
```
-rwxr-xr-x root/root    812720 2024-11-07 23:45 ./bin/busybox
-rwxr-xr-x root/root    947584 2024-11-07 23:45 ./bin/aux/nft
-rwxr-xr-x root/root   1121192 2024-11-07 23:45 ./bin/slirp4netns
```