### PR TITLE
Parallelize Drone Pipelines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 kind: pipeline
 type: docker
-name: k3s-root-linux-amd64
+name: k3s-root-linux
 
 platform:
   os: linux
@@ -10,6 +10,9 @@ platform:
 steps:
 - name: build-amd64
   image: rancher/dapper:v0.5.0
+  resources:
+    cpu: 7000
+    memory: 8Gi
   commands:
   - dapper ci
   environment:
@@ -19,7 +22,9 @@ steps:
   - name: docker
     path: /var/run/docker.sock
 
-- name: fossa
+- name: fossa-amd64
+  depends_on:
+    - build-amd64
   image: registry.suse.com/suse/sle15:15.6
   failure: ignore
   environment:
@@ -41,6 +46,8 @@ steps:
       - tag
 
 - name: github-amd64-binary-release
+  depends_on:
+    - fossa-amd64
   image: plugins/github-release
   settings:
     api_key:
@@ -51,6 +58,43 @@ steps:
     checksum_flatten: true
     files:
     - dist/k3s-*amd64.tar
+    prerelease: true
+  when:
+    event:
+    - tag
+    instance:
+    - drone-publish.k3s.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
+
+- name: build-riscv64
+  image: rancher/dapper:v0.5.0
+  resources:
+    cpu: 7000
+    memory: 8Gi
+  commands:
+  - dapper ci
+  environment:
+    BUILDARCH: riscv64
+    VERBOSE: "0"
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+
+- name: github-riscv64-binary-release
+  depends_on:
+    - build-riscv64
+  image: plugins/github-release
+  settings:
+    api_key:
+      from_secret: github_token
+    checksum:
+    - sha256
+    checksum_file: CHECKSUMsum-riscv64.txt
+    checksum_flatten: true
+    files:
+    - dist/k3s-*riscv64.tar
     prerelease: true
   when:
     event:
@@ -73,11 +117,14 @@ name: k3s-root-linux-arm64
 
 platform:
   os: linux
-  arch: amd64
+  arch: arm64
 
 steps:
 - name: build-arm64
   image: rancher/dapper:v0.5.0
+  # resources:
+  #   cpu: 7000
+  #   memory: 8Gi
   commands:
   - dapper ci
   environment:
@@ -88,6 +135,8 @@ steps:
     path: /var/run/docker.sock
 
 - name: github-arm64-binary-release
+  depends_on:
+    - build-arm64
   image: plugins/github-release
   settings:
     api_key:
@@ -112,7 +161,6 @@ volumes:
 - name: docker
   host:
     path: /var/run/docker.sock
-
 ---
 kind: pipeline
 type: docker
@@ -120,7 +168,7 @@ name: k3s-root-linux-arm
 
 platform:
   os: linux
-  arch: amd64
+  arch: arm
 
 steps:
 - name: build-arm
@@ -159,52 +207,3 @@ volumes:
 - name: docker
   host:
     path: /var/run/docker.sock
-
----
-kind: pipeline
-type: docker
-name: k3s-root-linux-riscv64
-
-platform:
-  os: linux
-  arch: amd64
-
-steps:
-- name: build-riscv64
-  image: rancher/dapper:v0.5.0
-  commands:
-  - dapper ci
-  environment:
-    BUILDARCH: riscv64
-    VERBOSE: "0"
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
-
-- name: github-riscv64-binary-release
-  image: plugins/github-release
-  settings:
-    api_key:
-      from_secret: github_token
-    checksum:
-    - sha256
-    checksum_file: CHECKSUMsum-riscv64.txt
-    checksum_flatten: true
-    files:
-    - dist/k3s-*riscv64.tar
-    prerelease: true
-  when:
-    event:
-    - tag
-    instance:
-    - drone-publish.k3s.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-
-volumes:
-- name: docker
-  host:
-    path: /var/run/docker.sock
-
-...

--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,7 @@ steps:
 - name: build-amd64
   image: rancher/dapper:v0.5.0
   resources:
-    cpu: 7000
+    cpu: 8000
     memory: 8Gi
   commands:
   - dapper ci
@@ -71,7 +71,7 @@ steps:
 - name: build-riscv64
   image: rancher/dapper:v0.5.0
   resources:
-    cpu: 7000
+    cpu: 8000
     memory: 8Gi
   commands:
   - dapper ci
@@ -113,7 +113,7 @@ volumes:
 ---
 kind: pipeline
 type: docker
-name: k3s-root-linux-arm64
+name: k3s-root-linux-arm
 
 platform:
   os: linux
@@ -122,9 +122,6 @@ platform:
 steps:
 - name: build-arm64
   image: rancher/dapper:v0.5.0
-  # resources:
-  #   cpu: 7000
-  #   memory: 8Gi
   commands:
   - dapper ci
   environment:
@@ -157,20 +154,6 @@ steps:
     - refs/head/master
     - refs/tags/*
 
-volumes:
-- name: docker
-  host:
-    path: /var/run/docker.sock
----
-kind: pipeline
-type: docker
-name: k3s-root-linux-arm
-
-platform:
-  os: linux
-  arch: arm
-
-steps:
 - name: build-arm
   image: rancher/dapper:v0.5.0
   commands:
@@ -183,6 +166,8 @@ steps:
     path: /var/run/docker.sock
 
 - name: github-arm-binary-release
+  depends_on:
+    - build-arm
   image: plugins/github-release
   settings:
     api_key:


### PR DESCRIPTION
Instead of moving to GHA, stay on Drone, but amd64 and riscv steps run in parallel on the same pipeline (amd64 host). Have arm and arm64 run in parallel on the same pipeline (arm64 host). 

This improved the entire Drone Job by about 100%, with typical build times falling from ~1h 15m to ~35m

| Old Time | New Time |
| - | - |
|![image](https://github.com/user-attachments/assets/86a6d8ba-994a-48bc-abc4-3401f7aaf210) | ![image](https://github.com/user-attachments/assets/45ac875a-d4ef-4b51-8456-5f526a941423) |
| ![image](https://github.com/user-attachments/assets/cb4559ef-9673-4817-b430-0a5b6bfdc493) | ![image](https://github.com/user-attachments/assets/ba334e50-b8d9-4697-b8c4-e45e3638fd2e) |

Performance on GHA
![image](https://github.com/user-attachments/assets/4ff33ff3-8d5c-492c-b49b-d231491eaed7)